### PR TITLE
Add support for blacklist of paths for content access via FTP

### DIFF
--- a/lftp/config.ini
+++ b/lftp/config.ini
@@ -15,3 +15,7 @@ basepaths =
 # directory.
 # The path specified should be relative to `basepaths` and contained within them
 chroot = 
+
+# List of paths which are to be made inaccessible via FTP. The paths are to be 
+# specified as regular expresessions.
+blacklist = 

--- a/lftp/ftpserver.py
+++ b/lftp/ftpserver.py
@@ -50,6 +50,7 @@ class LFTPServer(object):
 
         handler.abstracted_fs = UnifiedFilesystem
         handler.abstracted_fs.basepaths = basepaths
+        handler.abstracted_fs.blacklist = self.config.get('ftp.blacklist')
         authorizer.add_anonymous(basepaths[0])
         address = ('', self.config['ftp.port'])
         self.ftp_server = FTPServer(address, handler)


### PR DESCRIPTION
This PR adds enables a blacklist of paths with the content directories. All content within those paths will not be accessible via FTP. One common use case of this is to ignore junk directories created by filesystems, eg: $RECYCLER.BIN, lost+found

The paths are specified as a list of regular expressions under the key `ftp.blacklist`.
