### PR TITLE
Mirror exceptions (or their lack) in stdlib wrappers

### DIFF
--- a/lftp/ftp/filesystem.py
+++ b/lftp/ftp/filesystem.py
@@ -69,7 +69,7 @@ class UnifiedFilesystem(AbstractedFS):
         """
         This decorator provides a handy way to call stdlib function `stdlib_func`
         which accepts one path argument. If `exception` is set to `True`, an
-        :py:class:`OSError` will be raised if the path does not exist.
+        :py:exc:`OSError` will be raised if the path does not exist.
         """
         def decorator(func):
             @wraps(func)

--- a/lftp/ftp/filesystem.py
+++ b/lftp/ftp/filesystem.py
@@ -65,7 +65,7 @@ class UnifiedFilesystem(AbstractedFS):
             return func(self, virtual_path, *args, **kwargs)
         return wrapper
 
-    def stdlib_wrapper(stdlib_func):
+    def stdlib_wrapper(stdlib_func, exception=True):
         """
         This decorator provides a handy way to call stdlib functions which
         accept one path argument.
@@ -77,7 +77,8 @@ class UnifiedFilesystem(AbstractedFS):
                     full_path = normpaths(basepath, path)
                     if os.path.exists(full_path):
                         return stdlib_func(full_path)
-                raise_path_error(path)
+                if exception:
+                    raise_path_error(path)
             return wrapper
         return decorator
 
@@ -184,7 +185,7 @@ class UnifiedFilesystem(AbstractedFS):
         pass
 
     @virtualize_path
-    @stdlib_wrapper(os.path.isfile)
+    @stdlib_wrapper(os.path.isfile, exception=False)
     def isfile(self, path):
         """
         Wrapper for :py:func:`os.path.isfile`, which resolves `path` by
@@ -193,7 +194,7 @@ class UnifiedFilesystem(AbstractedFS):
         pass
 
     @virtualize_path
-    @stdlib_wrapper(os.path.islink)
+    @stdlib_wrapper(os.path.islink, exception=False)
     def islink(self, path):
         """
         Wrapper for :py:func:`os.path.islink`, which resolves `path` by
@@ -212,7 +213,7 @@ class UnifiedFilesystem(AbstractedFS):
             return self._isdir(path)
 
     @virtualize_path
-    @stdlib_wrapper(os.path.isdir)
+    @stdlib_wrapper(os.path.isdir, exception=False)
     def _isdir(self, path):
         """
         Wrapper for :py:func:`os.path.isdir`, which resolves `path` by

--- a/lftp/ftp/filesystem.py
+++ b/lftp/ftp/filesystem.py
@@ -67,8 +67,9 @@ class UnifiedFilesystem(AbstractedFS):
 
     def stdlib_wrapper(stdlib_func, exception=True):
         """
-        This decorator provides a handy way to call stdlib functions which
-        accept one path argument.
+        This decorator provides a handy way to call stdlib function `stdlib_func`
+        which accepts one path argument. If `exception` is set to `True`, an
+        :py:class:`OSError` will be raised if the path does not exist.
         """
         def decorator(func):
             @wraps(func)


### PR DESCRIPTION
This PR ensures that OSError exceptions are only raised if the underlying stdlib function is known to do so.
