### PR TITLE
Add common junk folders to blacklist

### DIFF
--- a/lftp/config.ini
+++ b/lftp/config.ini
@@ -19,3 +19,15 @@ chroot =
 # List of paths which are to be made inaccessible via FTP. The paths are to be 
 # specified as regular expresessions.
 blacklist = 
+  ^\.Trash.*
+  \.fseventsd
+  \.Spotlight-V100
+  .*/?\.DS_Store
+  \._.*
+  \.TemporaryItems
+  \$RECYCLE\.BIN
+  Recycler
+  System Volume Information
+  .*/?Thumbs\.db
+  .*/?\.thumbs
+  ^lost\+found(\/.*)?$


### PR DESCRIPTION
This PR adds a list of junk folders that will not show on the FTP listing. The entries are regular expressions and are the same as used by FSAL.

These junk folder names have been sourced from those known to be created by Windows, Linux and MacOS and are usually of no interest to the common user.
