### PR TITLE
Throughput optimizations for concurrent clients

### DIFF
--- a/lftp/ftpserver.py
+++ b/lftp/ftpserver.py
@@ -8,7 +8,7 @@ import os
 import logging
 import threading
 
-from pyftpdlib.servers import FTPServer
+from pyftpdlib.servers import MultiprocessFTPServer
 from pyftpdlib.handlers import FTPHandler
 
 from .ftp.authorizer import FTPAuthorizer
@@ -54,7 +54,7 @@ class LFTPServer(object):
         handler.use_sendfile = True
         authorizer.add_anonymous(basepaths[0])
         address = ('', self.config['ftp.port'])
-        self.ftp_server = FTPServer(address, handler)
+        self.ftp_server = MultiprocessFTPServer(address, handler)
 
     def teardown_ftp(self):
         self.ftp_server.close_all()

--- a/lftp/ftpserver.py
+++ b/lftp/ftpserver.py
@@ -51,6 +51,7 @@ class LFTPServer(object):
         handler.abstracted_fs = UnifiedFilesystem
         handler.abstracted_fs.basepaths = basepaths
         handler.abstracted_fs.blacklist = self.config.get('ftp.blacklist')
+        handler.use_sendfile = True
         authorizer.add_anonymous(basepaths[0])
         address = ('', self.config['ftp.port'])
         self.ftp_server = FTPServer(address, handler)

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     install_requires=[
         'librarian',
         'pyftpdlib',
+        'pysendfile',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
This PR caused lftp to use `sendfile` to transfer files & spawn a process for each connection. These two changes should give it better I/O throughput.

Resolves #14 
